### PR TITLE
Set base directory to look for native library

### DIFF
--- a/Evergine.LibraryLoader/Evergine.LibraryLoader/DefaultConfig.cs
+++ b/Evergine.LibraryLoader/Evergine.LibraryLoader/DefaultConfig.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright © Plain Concepts S.L.U. All rights reserved. Use is subject to license terms.
 
+using System.Reflection;
+
 namespace Evergine.LibraryLoader
 {
     /// <summary>
@@ -45,8 +47,30 @@ namespace Evergine.LibraryLoader
         /// <inheritdoc/>
         public string OSX_x64 => "runtimes/osx-x64/native";
 
+        /// <inheritdoc/>
+        public string BaseDirectory { get; private set; }
+
         private DefaultConfig()
         { 
+        }
+
+        /// <inheritdoc/>
+        public IConfig WithBaseDirectory(string baseDirectory)
+        {
+            BaseDirectory = baseDirectory;
+            return this;
+        }
+
+        /// <inheritdoc/>
+        public IConfig WithAssemblyDirectory(Assembly assembly)
+        {
+            return WithBaseDirectory(System.IO.Path.GetDirectoryName(assembly.Location));
+        }
+
+        /// <inheritdoc/>
+        public IConfig WithTypeAssemblyDirectory<T>()
+        {
+            return WithAssemblyDirectory(typeof(T).Assembly);
         }
     }
 }

--- a/Evergine.LibraryLoader/Evergine.LibraryLoader/IConfig.cs
+++ b/Evergine.LibraryLoader/Evergine.LibraryLoader/IConfig.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright © Plain Concepts S.L.U. All rights reserved. Use is subject to license terms.
 
+using System.Reflection;
+
 namespace Evergine.LibraryLoader
 {
     /// <summary>
@@ -7,6 +9,11 @@ namespace Evergine.LibraryLoader
     /// </summary>
     public interface IConfig
     {
+        /// <summary>
+        /// The base directory used to look for native libraries. If null the current directory is used.
+        /// </summary>
+        string BaseDirectory { get; }
+
         /// <summary>
         /// Windows platform and x86 architecture path.
         /// </summary>
@@ -61,5 +68,26 @@ namespace Evergine.LibraryLoader
         /// MacOS platform and x64 architecture path.
         /// </summary>
         string OSX_x64 { get; }
+
+        /// <summary>
+        /// Set the base directory used to look for native libraries.
+        /// </summary>
+        /// <param name="baseDirectory">The directory path.</param>
+        /// <returns>The current config instance.</returns>
+        IConfig WithBaseDirectory(string baseDirectory);
+
+        /// <summary>
+        /// Set the assembly directory to look for native libraries.
+        /// </summary>
+        /// <param name="assembly">The assembly.</param>
+        /// <returns>The current config instance.</returns>
+        IConfig WithAssemblyDirectory(Assembly assembly);
+
+        /// <summary>
+        /// Set the type assembly directory to look for native libraries.
+        /// </summary>
+        /// <typeparam name="T">The type.</typeparam>
+        /// <returns>The current config instance.</returns>
+        IConfig WithTypeAssemblyDirectory<T>();
     }
 }

--- a/Evergine.LibraryLoader/Evergine.LibraryLoader/ManualConfig.cs
+++ b/Evergine.LibraryLoader/Evergine.LibraryLoader/ManualConfig.cs
@@ -1,5 +1,8 @@
 ﻿// Copyright © Plain Concepts S.L.U. All rights reserved. Use is subject to license terms.
 
+using System.IO;
+using System.Reflection;
+
 namespace Evergine.LibraryLoader
 {
     /// <summary>
@@ -39,6 +42,9 @@ namespace Evergine.LibraryLoader
 
         /// <inheritdoc/>
         public string OSX_x64 { get; private set; }
+
+        /// <inheritdoc/>
+        public string BaseDirectory { get; private set; }
 
         private ManualConfig()
         {
@@ -181,6 +187,25 @@ namespace Evergine.LibraryLoader
         {
             this.OSX_x64 = path;
             return this;
+        }
+
+        /// <inheritdoc/>
+        public IConfig WithBaseDirectory(string baseDirectory)
+        {
+            this.BaseDirectory = baseDirectory;
+            return this;
+        }
+
+        /// <inheritdoc/>
+        public IConfig WithAssemblyDirectory(Assembly assembly)
+        {
+            return WithBaseDirectory(System.IO.Path.GetDirectoryName(assembly.Location));
+        }
+
+        /// <inheritdoc/>
+        public IConfig WithTypeAssemblyDirectory<T>()
+        {
+            return WithAssemblyDirectory(typeof(T).Assembly);
         }
     }
 }

--- a/Evergine.LibraryLoader/Evergine.LibraryLoader/NativeLoader.cs
+++ b/Evergine.LibraryLoader/Evergine.LibraryLoader/NativeLoader.cs
@@ -100,6 +100,11 @@ namespace Evergine.LibraryLoader
             }
 
             string libPath = System.IO.Path.Combine(runtime, libName);
+            if (lib.Config.BaseDirectory != null)
+            {
+                libPath = System.IO.Path.Combine(lib.Config.BaseDirectory, libPath);
+            }
+
             lib.Handle = NativeLoad(libPath);
             
             return lib.Handle;


### PR DESCRIPTION
Added a `BaseDirectory` property in IConfig and three methods to set it: `WithBaseDirectory`, `WithAssemblyDirectory`, and `WithTypeAssemblyDirectory`. These methods allow setting the base directory for native libraries using a string path, an `Assembly` instance, or a type's assembly respectively. 
Modified the `LoadLibrary` method to combine the `BaseDirectory` with the library path when loading libraries, if `BaseDirectory` is not null.